### PR TITLE
Add color utilities for mapping features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
       "devDependencies": {
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
+        "@types/papaparse": "^5.2.7",
+        "@types/uuid": "^9.0.7",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.5.4",
         "vite": "^5.4.0"
@@ -1115,6 +1117,16 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "devDependencies": {
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@types/papaparse": "^5.2.7",
+    "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.4",
     "vite": "^5.4.0"

--- a/src/types/papaparse.d.ts
+++ b/src/types/papaparse.d.ts
@@ -1,0 +1,1 @@
+declare module 'papaparse';

--- a/src/types/uuid.d.ts
+++ b/src/types/uuid.d.ts
@@ -1,0 +1,1 @@
+declare module 'uuid';

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,52 @@
+export function withAlpha(hex: string, alpha: number): string {
+  const normalized = hex.replace('#', '');
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (0 <= h && h < 60) {
+    r = c;
+    g = x;
+  } else if (60 <= h && h < 120) {
+    r = x;
+    g = c;
+  } else if (120 <= h && h < 180) {
+    g = c;
+    b = x;
+  } else if (180 <= h && h < 240) {
+    g = x;
+    b = c;
+  } else if (240 <= h && h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  const toHex = (n: number) => Math.round((n + m) * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export function generateDistinctColors(
+  count: number,
+  offset = 0
+): string[] {
+  const colors: string[] = [];
+  if (count <= 0) return colors;
+  for (let i = 0; i < count; i++) {
+    const hue = Math.round((360 * i) / count + offset) % 360;
+    colors.push(hslToHex(hue, 65, 55));
+  }
+  return colors;
+}

--- a/src/utils/plate.ts
+++ b/src/utils/plate.ts
@@ -1,5 +1,5 @@
 export const ROWS = ['A','B','C','D','E','F','G','H'] as const
-export const COLS = Array.from({length:12}, (_,i)=> (i+1)) as const
+export const COLS = [1,2,3,4,5,6,7,8,9,10,11,12] as const
 
 export const WELLS = ROWS.flatMap(r => COLS.map(c => `${r}${c}`))
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(__dirname, 'src')
     }
   }
 })


### PR DESCRIPTION
## Summary
- add color utility helpers for generating distinct sample colors and applying alpha values
- configure path alias and stub type declarations for papaparse/uuid
- fix plate column constant to satisfy TypeScript

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a3ce5e4832a8b720cd1f8b360cc