### PR TITLE
Add vitest test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "papaparse": "^5.4.1",
@@ -17,6 +18,8 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/papaparse": "^5.2.7",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -9,5 +9,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src')
     }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true
   }
 })


### PR DESCRIPTION
## Summary
- add vitest as test script and dependency
- configure vite to run vitest with jsdom environment

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca1dfe88c832abf89e14ef4f5ce7d