### PR TITLE
Enable direct color picking via sample icons

### DIFF
--- a/src/modules/mapping_manager/MappingManager.tsx
+++ b/src/modules/mapping_manager/MappingManager.tsx
@@ -205,9 +205,14 @@ export default function MappingManager() {
                       title={`Click to select sample "${s}"`}
                     >
                       <label
-                        className="color-chip"
                         title={`Pick color for sample ${s}`}
                         onClick={(e) => e.stopPropagation()}
+                        style={{
+                          position: 'relative',
+                          width: 14,
+                          height: 14,
+                          flex: '0 0 14px',
+                        }}
                       >
                         <input
                           type="color"
@@ -217,43 +222,40 @@ export default function MappingManager() {
                             mapping &&
                             setSampleColor(mapping.id, s, e.target.value)
                           }
+                          style={{
+                            position: 'absolute',
+                            inset: 0,
+                            opacity: 0,
+                            cursor: 'pointer',
+                          }}
                         />
-                        <span style={{ background: color }} />
-                      </label>
-                      <div
-                        style={{
-                          flex: 1,
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 6,
-                        }}
-                      >
                         <span
                           style={{
-                            display: 'inline-block',
+                            position: 'absolute',
+                            left: i === cursor ? 0 : 2,
+                            top: i === cursor ? 0 : 2,
                             width: i === cursor ? 0 : 10,
                             height: i === cursor ? 0 : 10,
-                            marginRight: i === cursor ? 0 : 0,
                             borderLeft:
-                              i === cursor ? '6px solid transparent' : undefined,
+                              i === cursor ? '7px solid transparent' : undefined,
                             borderRight:
-                              i === cursor ? '6px solid transparent' : undefined,
+                              i === cursor ? '7px solid transparent' : undefined,
                             borderBottom:
                               i === cursor
-                                ? `10px solid ${color}`
+                                ? `14px solid ${color}`
                                 : undefined,
                             background:
                               i === cursor ? undefined : color,
                             borderRadius: i === cursor ? undefined : '50%',
                           }}
                         />
-                        <span>
-                          {s}{' '}
-                          <span className="small">
-                            ({assignedCounts[s] ?? 0})
-                          </span>
+                      </label>
+                      <span>
+                        {s}{' '}
+                        <span className="small">
+                          ({assignedCounts[s] ?? 0})
                         </span>
-                      </div>
+                      </span>
                     </li>
                   );
                 })}

--- a/src/styles.css
+++ b/src/styles.css
@@ -435,39 +435,6 @@ h2 {
 }
 
 /* Color chip — pure circle, no background box, fixed size */
-.color-chip {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  border-radius: 9999px; /* circle */
-  overflow: hidden;
-  display: inline-block;
-  flex: 0 0 14px; /* don't stretch on wide screens */
-  background: transparent; /* ensure no pale rectangle */
-  border: 0; /* ensure no border box */
-}
-
-.color-chip > input[type='color'] {
-  position: absolute;
-  inset: 0;
-  opacity: 0; /* hide native UI */
-  cursor: pointer;
-  border: 0;
-  padding: 0;
-  margin: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  outline: none;
-}
-
-.color-chip > span {
-  position: absolute;
-  inset: 0;
-  border-radius: 9999px; /* circle fill */
-  background: transparent; /* actual color is set inline */
-}
-
 /* Responsive design */
 @media (max-width: 768px) {
   .landing h1 {


### PR DESCRIPTION
## Summary
- Let users click sample dots or triangles to change colors directly
- Show selected sample as triangle and drop unused color-chip CSS

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb7bfea20832a998fb98c7e4dc54d