### PR TITLE
feat: allow saturation adjustments and save in mapping

### DIFF
--- a/src/modules/mapping_manager/MappingManager.tsx
+++ b/src/modules/mapping_manager/MappingManager.tsx
@@ -19,6 +19,7 @@ export default function MappingManager() {
 
   // NEW: color actions
   const setSampleColor = useApp((s) => s.setSampleColor);
+  const setSampleSaturation = useApp((s) => s.setSampleSaturation);
   const randomizeSampleColors = useApp((s) => s.randomizeSampleColors);
 
   const activeList = activeListName ? sampleLists[activeListName] : null;
@@ -30,6 +31,7 @@ export default function MappingManager() {
   const assignments = mapping?.assignments ?? {};
   const samples = mapping?.samples ?? [];
   const sampleColors = mapping?.sampleColors ?? {};
+  const sampleSaturations = mapping?.sampleSaturations ?? {};
 
   useEffect(() => {
     setCursor(0);
@@ -40,7 +42,9 @@ export default function MappingManager() {
     if (
       mapping &&
       (!mapping.sampleColors ||
-        Object.keys(mapping.sampleColors).length !== mapping.samples.length)
+        Object.keys(mapping.sampleColors).length !== mapping.samples.length ||
+        !mapping.sampleSaturations ||
+        Object.keys(mapping.sampleSaturations).length !== mapping.samples.length)
     ) {
       randomizeSampleColors(mapping.id);
     }
@@ -71,6 +75,10 @@ export default function MappingManager() {
     const rows = WELLS.map((w) => ({
       well: w,
       sampleName: assignments[w] ?? '',
+      color: assignments[w] ? sampleColors[assignments[w]] ?? '' : '',
+      saturation: assignments[w]
+        ? sampleSaturations[assignments[w]] ?? ''
+        : '',
     }));
     downloadCSV(`${mapping.name.replace(/\s+/g, '_')}.mapping.csv`, rows);
   }
@@ -194,6 +202,7 @@ export default function MappingManager() {
               <ol>
                 {samples.map((s, i) => {
                   const color = sampleColors[s] ?? '#60a5fa';
+                  const sat = sampleSaturations[s] ?? 65;
                   return (
                     <li
                       key={i}
@@ -250,12 +259,29 @@ export default function MappingManager() {
                           }}
                         />
                       </label>
-                      <span>
+                      <span style={{ flex: 1 }}>
                         {s}{' '}
                         <span className="small">
                           ({assignedCounts[s] ?? 0})
                         </span>
                       </span>
+                      <input
+                        type="range"
+                        min={0}
+                        max={100}
+                        value={sat}
+                        title={`Saturation for ${s}`}
+                        onChange={(e) =>
+                          mapping &&
+                          setSampleSaturation(
+                            mapping.id,
+                            s,
+                            Number(e.target.value)
+                          )
+                        }
+                        style={{ width: 80 }}
+                        onClick={(e) => e.stopPropagation()}
+                      />
                     </li>
                   );
                 })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface Mapping {
   assignments: Record<string, string>; // well -> sampleName
   samples: string[];
   sampleColors?: Record<string, string>; // sampleName -> hex (#rrggbb)
+  sampleSaturations?: Record<string, number>; // sampleName -> saturation 0-100
   notes?: string;
 }
 

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -6,7 +6,7 @@ export function withAlpha(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-function hslToHex(h: number, s: number, l: number): string {
+export function hslToHex(h: number, s: number, l: number): string {
   s /= 100;
   l /= 100;
   const c = (1 - Math.abs(2 * l - 1)) * s;
@@ -38,6 +38,35 @@ function hslToHex(h: number, s: number, l: number): string {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
+export function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const normalized = hex.replace('#', '');
+  const r = parseInt(normalized.slice(0, 2), 16) / 255;
+  const g = parseInt(normalized.slice(2, 4), 16) / 255;
+  const b = parseInt(normalized.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return { h, s: s * 100, l: l * 100 };
+}
+
 export function generateDistinctColors(
   count: number,
   offset = 0
@@ -46,7 +75,8 @@ export function generateDistinctColors(
   if (count <= 0) return colors;
   for (let i = 0; i < count; i++) {
     const hue = Math.round((360 * i) / count + offset) % 360;
-    colors.push(hslToHex(hue, 65, 55));
+    const saturation = 45 + Math.random() * 35; // 45-80
+    colors.push(hslToHex(hue, saturation, 55));
   }
   return colors;
 }


### PR DESCRIPTION
## Summary
- randomize sample colors now varies hue and saturation
- allow manual saturation tuning for each sample and save to mapping export
- track saturation values in mapping state for persistence

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb98dd9d0832a943a857ddbc08d49