### PR TITLE
Rename mapping manager to creator and adjust tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Minimalna przeglądarkowa aplikacja (Vite + React + TypeScript), skupiona na pierwszych modułach:
 - **Sample Manager** — tworzenie i zarządzanie listami próbek
-- **Input Files Converter** — parsowanie plików CSV/TXT do zunifikowanego formatu (OD600)
-- **Mapping Manager** — przypisywanie próbek do dołków 96-well
+- **Mapping Creator** — przypisywanie próbek do dołków 96-well
 - **Mapping Assigner** — łączenie mappingu z danymi i eksport CSV
+- **Input Files Converter** — parsowanie plików CSV/TXT do zunifikowanego formatu (OD600)
 
 Pozostałe moduły są na razie **stubami**.
 
@@ -33,13 +33,13 @@ Każdy wiersz danych (OD na razie) zawiera:
 
 ## Sterowanie mappingiem
 
-- Wybór listy próbek w Sample Manager, potem w Mapping Manager utwórz nowe mapowanie z aktywnej listy.
+- Wybór listy próbek w Sample Manager, potem w Mapping Creator utwórz nowe mapowanie z aktywnej listy.
 - Kliknięcie dołka przypisuje aktualnie wybraną próbkę; ponowne kliknięcie czyści.
 - Strzałki `↑/↓` zmieniają aktywną próbkę.
 
 ## Eksport
 
-- W **Mapping Manager** można wyeksportować CSV z mapowaniem (`well,sampleName`).
+- W **Mapping Creator** można wyeksportować CSV z mapowaniem (`well,sampleName`).
 - W **Mapping Assigner** można wyeksportować pełne dane z `sampleName` jako CSV.
 
 ## Licencja

--- a/src/modules/mapping_creator/MappingCreator.tsx
+++ b/src/modules/mapping_creator/MappingCreator.tsx
@@ -6,7 +6,7 @@ import type { Mapping } from '@/types';
 import { downloadCSV } from '@/utils/csv';
 import { withAlpha } from '@/utils/colors';
 
-export default function MappingManager() {
+export default function MappingCreator() {
   const sampleLists = useApp((s) => s.sampleLists);
   const activeListName = useApp((s) => s.activeSampleListName);
   const createMapping = useApp((s) => s.createMapping);
@@ -101,7 +101,7 @@ export default function MappingManager() {
 
   return (
     <div className="panel">
-      <h2>Mapping Manager</h2>
+      <h2>Mapping Creator</h2>
       <div className="small">
         Click the colored square to change color; click a row to make that sample
         active. Use <span className="kbd">↑/↓</span> to move the active sample.
@@ -125,7 +125,7 @@ export default function MappingManager() {
               {Object.values(mappings).length === 0 && (
                 <div className="small">No mappings yet.</div>
               )}
-              <ul>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                 {Object.values(mappings).map((m) => (
                   <li key={m.id} style={{ marginBottom: 6 }}>
                     <label

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -2,7 +2,7 @@ import { useApp } from '@/state/store'
 import LandingPage from './LandingPage'
 import SampleManager from '@/modules/sample_manager/SampleManager'
 import InputFilesConverter from '@/modules/input_files_converter/InputFilesConverter'
-import MappingManager from '@/modules/mapping_manager/MappingManager'
+import MappingCreator from '@/modules/mapping_creator/MappingCreator'
 import MappingAssigner from '@/modules/mapping_assigner/MappingAssigner'
 import PlotsViewer from '@/modules/plots_viewer/PlotsViewer'
 import OutputCreator from '@/modules/output_file_creator/OutputCreator'
@@ -13,9 +13,9 @@ import DataAnalyser from '@/modules/data_analyser/DataAnalyser'
 const tabs = [
   { id: 'home', label: 'Home'},
   { id: 'samples', label: 'Sample Manager'},
-  { id: 'mapping', label: 'Mapping Manager'},
-  { id: 'converter', label: 'Input Files Converter'},
+  { id: 'mapping', label: 'Mapping Creator'},
   { id: 'assign', label: 'Mapping Assigner'},
+  { id: 'converter', label: 'Input Files Converter'},
   { id: 'plots', label: 'Plots Viewer'},
   { id: 'interactive', label: 'Interactive Plots'},
   { id: 'compiler', label: 'Plots Compiler'},
@@ -45,9 +45,9 @@ export default function App(){
       <div className="container">
         {activeTab==='home' && <LandingPage/>}
         {activeTab==='samples' && <SampleManager/>}
-        {activeTab==='converter' && <InputFilesConverter/>}
-        {activeTab==='mapping' && <MappingManager/>}
+        {activeTab==='mapping' && <MappingCreator/>}
         {activeTab==='assign' && <MappingAssigner/>}
+        {activeTab==='converter' && <InputFilesConverter/>}
         {activeTab==='plots' && <PlotsViewer/>}
         {activeTab==='interactive' && <InteractivePlotsViewer/>}
         {activeTab==='compiler' && <InteractivePlotsCompiler/>}


### PR DESCRIPTION
## Summary
- rename Mapping Manager module and UI elements to Mapping Creator
- move Mapping Assigner tab before Input Files Converter
- hide mapping list bullet and update docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68acbb2da2dc832a90f16a2b2abac251