### PR TITLE
Improve well color contrast for Mapping Manager

### DIFF
--- a/src/modules/mapping_manager/MappingManager.tsx
+++ b/src/modules/mapping_manager/MappingManager.tsx
@@ -316,8 +316,9 @@ export default function MappingManager() {
                     const isActiveSample = assigned && assigned === samples[cursor];
                     const style: CSSProperties = {};
                     if (assigned) {
-                      style.background = withAlpha(color, 0.18);
-                      style.borderColor = withAlpha(color, 0.55);
+                      // Increase opacity so sample colors are easier to distinguish
+                      style.background = withAlpha(color, 0.35);
+                      style.borderColor = withAlpha(color, 0.8);
                     }
                     if (isActiveSample) {
                       style.boxShadow = '0 0 0 2px var(--accent)';


### PR DESCRIPTION
## Summary
- increase opacity of assigned well colors to make samples easier to distinguish

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc6fb378832a805e06423d45d205