### PR TITLE
feat: add temporary mapping save button

### DIFF
--- a/src/modules/mapping_manager/MappingManager.tsx
+++ b/src/modules/mapping_manager/MappingManager.tsx
@@ -16,6 +16,7 @@ export default function MappingManager() {
   const updateAssignments = useApp((s) => s.updateMappingAssignments);
   const renameMapping = useApp((s) => s.renameMapping);
   const deleteMapping = useApp((s) => s.deleteMapping);
+  const setActiveTab = useApp((s) => s.setActiveTab);
 
   // NEW: color actions
   const setSampleColor = useApp((s) => s.setSampleColor);
@@ -166,6 +167,12 @@ export default function MappingManager() {
             </div>
             {mapping && (
               <div className="row" style={{ marginTop: 8, gap: 8 }}>
+                <button
+                  className="btn primary"
+                  onClick={() => setActiveTab('assign')}
+                >
+                  Save Temporarely
+                </button>
                 <button className="btn" onClick={exportCSV}>
                   Export CSV
                 </button>


### PR DESCRIPTION
## Summary
- allow saving mapping without exporting by adding "Save Temporarely" button
- navigate directly to Mapping Assigner after saving

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68acbded9b34832a90b2362eb624aa1f